### PR TITLE
Renamed group ID to com.agolo.de.mpii

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,5 +64,5 @@ dependencies {
     compile group: 'ch.qos.logback', name: 'logback-core', version:'1.1.8'
     compile group: 'com.google.code.findbugs', name: 'jsr305', version:'3.0.1'
     testCompile group: 'junit', name: 'junit', version:'4.12'
-    compileOnly group: 'edu.stanford.nlp', name: 'stanford-corenlp', version:'3.7.0', classifier:'models-english'
+    compile group: 'edu.stanford.nlp', name: 'stanford-corenlp', version:'3.7.0', classifier:'models-english'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'java'
 apply plugin: 'maven'
 
-group = 'de.mpii.clausie'
+group = 'com.agolo.de.mpii'
 version = '0.1.2'
 
 description = """"""


### PR DESCRIPTION
The gradle `testCompile` configuration weren't compiling correctly because stanford-corenlp-models was not included in `testCompile`.